### PR TITLE
Fix test page component names

### DIFF
--- a/synthetic-react-app/scripts/generateTestPage.ts
+++ b/synthetic-react-app/scripts/generateTestPage.ts
@@ -4,6 +4,8 @@ import path from 'path';
 import ejs from 'ejs';
 
 const baseDir = path.resolve(__dirname, '..');
+const toPascalCase = (str: string) =>
+  str.replace(/(^\w|-\w)/g, (s) => s.replace('-', '').toUpperCase());
 const pagesConfig = require(path.join(baseDir, 'src/config/testPages.json'));
 const templatesDir = path.join(baseDir, 'src/templates');
 const outputBase = path.join(baseDir, 'src/pages/test-data');
@@ -43,10 +45,11 @@ const generateComponentChain = async (
     const pageDir = path.join(outputBase, config.pageName);
     await fs.ensureDir(pageDir);
 
+    const componentName = toPascalCase(config.pageName);
     await renderAndWrite(
       path.join(templatesDir, 'Page.ejs'),
       path.join(pageDir, 'index.tsx'),
-      { pageName: config.pageName, layout: config.layout, pattern: config.pattern }
+      { pageName: config.pageName, componentName, layout: config.layout, pattern: config.pattern }
     );
 
     await generateComponentChain(

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest1/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest1/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest1 = () => {
+const InefficientcontextTest1 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inefficientcontextTest1</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest1 = () => {
   );
 };
 
-export default inefficientcontextTest1;
+export default InefficientcontextTest1;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest10/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest10/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest10 = () => {
+const InefficientcontextTest10 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inefficientcontextTest10</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest10 = () => {
   );
 };
 
-export default inefficientcontextTest10;
+export default InefficientcontextTest10;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest11/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest11/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest11 = () => {
+const InefficientcontextTest11 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inefficientcontextTest11</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest11 = () => {
   );
 };
 
-export default inefficientcontextTest11;
+export default InefficientcontextTest11;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest12/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest12/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest12 = () => {
+const InefficientcontextTest12 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inefficientcontextTest12</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest12 = () => {
   );
 };
 
-export default inefficientcontextTest12;
+export default InefficientcontextTest12;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest13/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest13/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest13 = () => {
+const InefficientcontextTest13 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inefficientcontextTest13</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest13 = () => {
   );
 };
 
-export default inefficientcontextTest13;
+export default InefficientcontextTest13;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest14/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest14/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest14 = () => {
+const InefficientcontextTest14 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inefficientcontextTest14</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest14 = () => {
   );
 };
 
-export default inefficientcontextTest14;
+export default InefficientcontextTest14;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest15/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest15/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest15 = () => {
+const InefficientcontextTest15 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inefficientcontextTest15</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest15 = () => {
   );
 };
 
-export default inefficientcontextTest15;
+export default InefficientcontextTest15;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest16/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest16/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest16 = () => {
+const InefficientcontextTest16 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inefficientcontextTest16</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest16 = () => {
   );
 };
 
-export default inefficientcontextTest16;
+export default InefficientcontextTest16;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest17/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest17/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest17 = () => {
+const InefficientcontextTest17 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inefficientcontextTest17</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest17 = () => {
   );
 };
 
-export default inefficientcontextTest17;
+export default InefficientcontextTest17;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest18/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest18/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest18 = () => {
+const InefficientcontextTest18 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inefficientcontextTest18</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest18 = () => {
   );
 };
 
-export default inefficientcontextTest18;
+export default InefficientcontextTest18;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest19/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest19/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest19 = () => {
+const InefficientcontextTest19 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inefficientcontextTest19</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest19 = () => {
   );
 };
 
-export default inefficientcontextTest19;
+export default InefficientcontextTest19;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest2/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest2/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest2 = () => {
+const InefficientcontextTest2 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inefficientcontextTest2</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest2 = () => {
   );
 };
 
-export default inefficientcontextTest2;
+export default InefficientcontextTest2;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest20/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest20/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest20 = () => {
+const InefficientcontextTest20 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inefficientcontextTest20</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest20 = () => {
   );
 };
 
-export default inefficientcontextTest20;
+export default InefficientcontextTest20;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest21/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest21/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest21 = () => {
+const InefficientcontextTest21 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inefficientcontextTest21</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest21 = () => {
   );
 };
 
-export default inefficientcontextTest21;
+export default InefficientcontextTest21;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest22/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest22/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest22 = () => {
+const InefficientcontextTest22 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inefficientcontextTest22</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest22 = () => {
   );
 };
 
-export default inefficientcontextTest22;
+export default InefficientcontextTest22;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest23/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest23/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest23 = () => {
+const InefficientcontextTest23 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inefficientcontextTest23</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest23 = () => {
   );
 };
 
-export default inefficientcontextTest23;
+export default InefficientcontextTest23;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest24/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest24/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest24 = () => {
+const InefficientcontextTest24 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inefficientcontextTest24</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest24 = () => {
   );
 };
 
-export default inefficientcontextTest24;
+export default InefficientcontextTest24;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest25/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest25/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest25 = () => {
+const InefficientcontextTest25 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inefficientcontextTest25</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest25 = () => {
   );
 };
 
-export default inefficientcontextTest25;
+export default InefficientcontextTest25;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest26/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest26/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest26 = () => {
+const InefficientcontextTest26 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inefficientcontextTest26</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest26 = () => {
   );
 };
 
-export default inefficientcontextTest26;
+export default InefficientcontextTest26;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest27/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest27/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest27 = () => {
+const InefficientcontextTest27 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inefficientcontextTest27</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest27 = () => {
   );
 };
 
-export default inefficientcontextTest27;
+export default InefficientcontextTest27;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest28/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest28/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest28 = () => {
+const InefficientcontextTest28 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inefficientcontextTest28</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest28 = () => {
   );
 };
 
-export default inefficientcontextTest28;
+export default InefficientcontextTest28;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest29/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest29/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest29 = () => {
+const InefficientcontextTest29 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inefficientcontextTest29</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest29 = () => {
   );
 };
 
-export default inefficientcontextTest29;
+export default InefficientcontextTest29;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest3/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest3/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest3 = () => {
+const InefficientcontextTest3 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inefficientcontextTest3</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest3 = () => {
   );
 };
 
-export default inefficientcontextTest3;
+export default InefficientcontextTest3;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest30/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest30/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest30 = () => {
+const InefficientcontextTest30 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inefficientcontextTest30</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest30 = () => {
   );
 };
 
-export default inefficientcontextTest30;
+export default InefficientcontextTest30;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest4/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest4/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest4 = () => {
+const InefficientcontextTest4 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inefficientcontextTest4</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest4 = () => {
   );
 };
 
-export default inefficientcontextTest4;
+export default InefficientcontextTest4;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest5/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest5/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest5 = () => {
+const InefficientcontextTest5 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inefficientcontextTest5</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest5 = () => {
   );
 };
 
-export default inefficientcontextTest5;
+export default InefficientcontextTest5;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest6/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest6/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest6 = () => {
+const InefficientcontextTest6 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inefficientcontextTest6</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest6 = () => {
   );
 };
 
-export default inefficientcontextTest6;
+export default InefficientcontextTest6;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest7/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest7/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest7 = () => {
+const InefficientcontextTest7 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inefficientcontextTest7</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest7 = () => {
   );
 };
 
-export default inefficientcontextTest7;
+export default InefficientcontextTest7;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest8/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest8/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest8 = () => {
+const InefficientcontextTest8 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inefficientcontextTest8</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest8 = () => {
   );
 };
 
-export default inefficientcontextTest8;
+export default InefficientcontextTest8;

--- a/synthetic-react-app/src/pages/test-data/inefficientcontextTest9/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inefficientcontextTest9/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inefficientcontextTest9 = () => {
+const InefficientcontextTest9 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inefficientcontextTest9</h2>
@@ -10,4 +10,4 @@ const inefficientcontextTest9 = () => {
   );
 };
 
-export default inefficientcontextTest9;
+export default InefficientcontextTest9;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest1/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest1/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest1 = () => {
+const InlinefunctionsTest1 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inlinefunctionsTest1</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest1 = () => {
   );
 };
 
-export default inlinefunctionsTest1;
+export default InlinefunctionsTest1;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest10/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest10/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest10 = () => {
+const InlinefunctionsTest10 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inlinefunctionsTest10</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest10 = () => {
   );
 };
 
-export default inlinefunctionsTest10;
+export default InlinefunctionsTest10;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest11/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest11/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest11 = () => {
+const InlinefunctionsTest11 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inlinefunctionsTest11</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest11 = () => {
   );
 };
 
-export default inlinefunctionsTest11;
+export default InlinefunctionsTest11;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest12/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest12/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest12 = () => {
+const InlinefunctionsTest12 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inlinefunctionsTest12</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest12 = () => {
   );
 };
 
-export default inlinefunctionsTest12;
+export default InlinefunctionsTest12;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest13/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest13/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest13 = () => {
+const InlinefunctionsTest13 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inlinefunctionsTest13</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest13 = () => {
   );
 };
 
-export default inlinefunctionsTest13;
+export default InlinefunctionsTest13;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest14/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest14/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest14 = () => {
+const InlinefunctionsTest14 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inlinefunctionsTest14</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest14 = () => {
   );
 };
 
-export default inlinefunctionsTest14;
+export default InlinefunctionsTest14;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest15/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest15/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest15 = () => {
+const InlinefunctionsTest15 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inlinefunctionsTest15</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest15 = () => {
   );
 };
 
-export default inlinefunctionsTest15;
+export default InlinefunctionsTest15;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest16/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest16/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest16 = () => {
+const InlinefunctionsTest16 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inlinefunctionsTest16</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest16 = () => {
   );
 };
 
-export default inlinefunctionsTest16;
+export default InlinefunctionsTest16;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest17/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest17/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest17 = () => {
+const InlinefunctionsTest17 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inlinefunctionsTest17</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest17 = () => {
   );
 };
 
-export default inlinefunctionsTest17;
+export default InlinefunctionsTest17;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest18/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest18/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest18 = () => {
+const InlinefunctionsTest18 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inlinefunctionsTest18</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest18 = () => {
   );
 };
 
-export default inlinefunctionsTest18;
+export default InlinefunctionsTest18;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest19/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest19/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest19 = () => {
+const InlinefunctionsTest19 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inlinefunctionsTest19</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest19 = () => {
   );
 };
 
-export default inlinefunctionsTest19;
+export default InlinefunctionsTest19;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest2/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest2/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest2 = () => {
+const InlinefunctionsTest2 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inlinefunctionsTest2</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest2 = () => {
   );
 };
 
-export default inlinefunctionsTest2;
+export default InlinefunctionsTest2;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest20/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest20/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest20 = () => {
+const InlinefunctionsTest20 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inlinefunctionsTest20</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest20 = () => {
   );
 };
 
-export default inlinefunctionsTest20;
+export default InlinefunctionsTest20;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest21/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest21/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest21 = () => {
+const InlinefunctionsTest21 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inlinefunctionsTest21</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest21 = () => {
   );
 };
 
-export default inlinefunctionsTest21;
+export default InlinefunctionsTest21;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest22/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest22/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest22 = () => {
+const InlinefunctionsTest22 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inlinefunctionsTest22</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest22 = () => {
   );
 };
 
-export default inlinefunctionsTest22;
+export default InlinefunctionsTest22;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest23/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest23/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest23 = () => {
+const InlinefunctionsTest23 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inlinefunctionsTest23</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest23 = () => {
   );
 };
 
-export default inlinefunctionsTest23;
+export default InlinefunctionsTest23;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest24/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest24/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest24 = () => {
+const InlinefunctionsTest24 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inlinefunctionsTest24</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest24 = () => {
   );
 };
 
-export default inlinefunctionsTest24;
+export default InlinefunctionsTest24;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest25/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest25/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest25 = () => {
+const InlinefunctionsTest25 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inlinefunctionsTest25</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest25 = () => {
   );
 };
 
-export default inlinefunctionsTest25;
+export default InlinefunctionsTest25;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest26/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest26/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest26 = () => {
+const InlinefunctionsTest26 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inlinefunctionsTest26</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest26 = () => {
   );
 };
 
-export default inlinefunctionsTest26;
+export default InlinefunctionsTest26;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest27/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest27/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest27 = () => {
+const InlinefunctionsTest27 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inlinefunctionsTest27</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest27 = () => {
   );
 };
 
-export default inlinefunctionsTest27;
+export default InlinefunctionsTest27;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest28/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest28/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest28 = () => {
+const InlinefunctionsTest28 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inlinefunctionsTest28</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest28 = () => {
   );
 };
 
-export default inlinefunctionsTest28;
+export default InlinefunctionsTest28;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest29/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest29/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest29 = () => {
+const InlinefunctionsTest29 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inlinefunctionsTest29</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest29 = () => {
   );
 };
 
-export default inlinefunctionsTest29;
+export default InlinefunctionsTest29;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest3/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest3/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest3 = () => {
+const InlinefunctionsTest3 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inlinefunctionsTest3</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest3 = () => {
   );
 };
 
-export default inlinefunctionsTest3;
+export default InlinefunctionsTest3;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest30/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest30/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest30 = () => {
+const InlinefunctionsTest30 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inlinefunctionsTest30</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest30 = () => {
   );
 };
 
-export default inlinefunctionsTest30;
+export default InlinefunctionsTest30;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest4/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest4/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest4 = () => {
+const InlinefunctionsTest4 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inlinefunctionsTest4</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest4 = () => {
   );
 };
 
-export default inlinefunctionsTest4;
+export default InlinefunctionsTest4;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest5/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest5/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest5 = () => {
+const InlinefunctionsTest5 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inlinefunctionsTest5</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest5 = () => {
   );
 };
 
-export default inlinefunctionsTest5;
+export default InlinefunctionsTest5;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest6/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest6/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest6 = () => {
+const InlinefunctionsTest6 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inlinefunctionsTest6</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest6 = () => {
   );
 };
 
-export default inlinefunctionsTest6;
+export default InlinefunctionsTest6;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest7/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest7/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest7 = () => {
+const InlinefunctionsTest7 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inlinefunctionsTest7</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest7 = () => {
   );
 };
 
-export default inlinefunctionsTest7;
+export default InlinefunctionsTest7;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest8/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest8/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest8 = () => {
+const InlinefunctionsTest8 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>inlinefunctionsTest8</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest8 = () => {
   );
 };
 
-export default inlinefunctionsTest8;
+export default InlinefunctionsTest8;

--- a/synthetic-react-app/src/pages/test-data/inlinefunctionsTest9/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/inlinefunctionsTest9/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const inlinefunctionsTest9 = () => {
+const InlinefunctionsTest9 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>inlinefunctionsTest9</h2>
@@ -10,4 +10,4 @@ const inlinefunctionsTest9 = () => {
   );
 };
 
-export default inlinefunctionsTest9;
+export default InlinefunctionsTest9;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest1/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest1/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest1 = () => {
+const LazyloadingTest1 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>lazyloadingTest1</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest1 = () => {
   );
 };
 
-export default lazyloadingTest1;
+export default LazyloadingTest1;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest10/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest10/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest10 = () => {
+const LazyloadingTest10 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>lazyloadingTest10</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest10 = () => {
   );
 };
 
-export default lazyloadingTest10;
+export default LazyloadingTest10;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest11/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest11/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest11 = () => {
+const LazyloadingTest11 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>lazyloadingTest11</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest11 = () => {
   );
 };
 
-export default lazyloadingTest11;
+export default LazyloadingTest11;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest12/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest12/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest12 = () => {
+const LazyloadingTest12 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>lazyloadingTest12</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest12 = () => {
   );
 };
 
-export default lazyloadingTest12;
+export default LazyloadingTest12;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest13/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest13/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest13 = () => {
+const LazyloadingTest13 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>lazyloadingTest13</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest13 = () => {
   );
 };
 
-export default lazyloadingTest13;
+export default LazyloadingTest13;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest14/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest14/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest14 = () => {
+const LazyloadingTest14 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>lazyloadingTest14</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest14 = () => {
   );
 };
 
-export default lazyloadingTest14;
+export default LazyloadingTest14;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest15/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest15/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest15 = () => {
+const LazyloadingTest15 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>lazyloadingTest15</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest15 = () => {
   );
 };
 
-export default lazyloadingTest15;
+export default LazyloadingTest15;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest16/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest16/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest16 = () => {
+const LazyloadingTest16 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>lazyloadingTest16</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest16 = () => {
   );
 };
 
-export default lazyloadingTest16;
+export default LazyloadingTest16;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest17/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest17/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest17 = () => {
+const LazyloadingTest17 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>lazyloadingTest17</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest17 = () => {
   );
 };
 
-export default lazyloadingTest17;
+export default LazyloadingTest17;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest18/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest18/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest18 = () => {
+const LazyloadingTest18 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>lazyloadingTest18</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest18 = () => {
   );
 };
 
-export default lazyloadingTest18;
+export default LazyloadingTest18;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest19/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest19/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest19 = () => {
+const LazyloadingTest19 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>lazyloadingTest19</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest19 = () => {
   );
 };
 
-export default lazyloadingTest19;
+export default LazyloadingTest19;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest2/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest2/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest2 = () => {
+const LazyloadingTest2 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>lazyloadingTest2</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest2 = () => {
   );
 };
 
-export default lazyloadingTest2;
+export default LazyloadingTest2;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest20/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest20/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest20 = () => {
+const LazyloadingTest20 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>lazyloadingTest20</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest20 = () => {
   );
 };
 
-export default lazyloadingTest20;
+export default LazyloadingTest20;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest21/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest21/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest21 = () => {
+const LazyloadingTest21 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>lazyloadingTest21</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest21 = () => {
   );
 };
 
-export default lazyloadingTest21;
+export default LazyloadingTest21;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest22/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest22/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest22 = () => {
+const LazyloadingTest22 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>lazyloadingTest22</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest22 = () => {
   );
 };
 
-export default lazyloadingTest22;
+export default LazyloadingTest22;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest23/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest23/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest23 = () => {
+const LazyloadingTest23 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>lazyloadingTest23</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest23 = () => {
   );
 };
 
-export default lazyloadingTest23;
+export default LazyloadingTest23;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest24/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest24/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest24 = () => {
+const LazyloadingTest24 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>lazyloadingTest24</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest24 = () => {
   );
 };
 
-export default lazyloadingTest24;
+export default LazyloadingTest24;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest25/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest25/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest25 = () => {
+const LazyloadingTest25 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>lazyloadingTest25</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest25 = () => {
   );
 };
 
-export default lazyloadingTest25;
+export default LazyloadingTest25;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest26/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest26/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest26 = () => {
+const LazyloadingTest26 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>lazyloadingTest26</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest26 = () => {
   );
 };
 
-export default lazyloadingTest26;
+export default LazyloadingTest26;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest27/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest27/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest27 = () => {
+const LazyloadingTest27 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>lazyloadingTest27</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest27 = () => {
   );
 };
 
-export default lazyloadingTest27;
+export default LazyloadingTest27;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest28/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest28/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest28 = () => {
+const LazyloadingTest28 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>lazyloadingTest28</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest28 = () => {
   );
 };
 
-export default lazyloadingTest28;
+export default LazyloadingTest28;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest29/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest29/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest29 = () => {
+const LazyloadingTest29 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>lazyloadingTest29</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest29 = () => {
   );
 };
 
-export default lazyloadingTest29;
+export default LazyloadingTest29;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest3/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest3/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest3 = () => {
+const LazyloadingTest3 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>lazyloadingTest3</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest3 = () => {
   );
 };
 
-export default lazyloadingTest3;
+export default LazyloadingTest3;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest30/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest30/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest30 = () => {
+const LazyloadingTest30 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>lazyloadingTest30</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest30 = () => {
   );
 };
 
-export default lazyloadingTest30;
+export default LazyloadingTest30;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest4/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest4/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest4 = () => {
+const LazyloadingTest4 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>lazyloadingTest4</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest4 = () => {
   );
 };
 
-export default lazyloadingTest4;
+export default LazyloadingTest4;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest5/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest5/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest5 = () => {
+const LazyloadingTest5 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>lazyloadingTest5</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest5 = () => {
   );
 };
 
-export default lazyloadingTest5;
+export default LazyloadingTest5;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest6/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest6/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest6 = () => {
+const LazyloadingTest6 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>lazyloadingTest6</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest6 = () => {
   );
 };
 
-export default lazyloadingTest6;
+export default LazyloadingTest6;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest7/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest7/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest7 = () => {
+const LazyloadingTest7 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>lazyloadingTest7</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest7 = () => {
   );
 };
 
-export default lazyloadingTest7;
+export default LazyloadingTest7;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest8/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest8/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest8 = () => {
+const LazyloadingTest8 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>lazyloadingTest8</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest8 = () => {
   );
 };
 
-export default lazyloadingTest8;
+export default LazyloadingTest8;

--- a/synthetic-react-app/src/pages/test-data/lazyloadingTest9/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/lazyloadingTest9/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const lazyloadingTest9 = () => {
+const LazyloadingTest9 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>lazyloadingTest9</h2>
@@ -10,4 +10,4 @@ const lazyloadingTest9 = () => {
   );
 };
 
-export default lazyloadingTest9;
+export default LazyloadingTest9;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest1/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest1/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest1 = () => {
+const MissinguseMemoTest1 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>missinguseMemoTest1</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest1 = () => {
   );
 };
 
-export default missinguseMemoTest1;
+export default MissinguseMemoTest1;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest10/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest10/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest10 = () => {
+const MissinguseMemoTest10 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>missinguseMemoTest10</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest10 = () => {
   );
 };
 
-export default missinguseMemoTest10;
+export default MissinguseMemoTest10;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest11/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest11/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest11 = () => {
+const MissinguseMemoTest11 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>missinguseMemoTest11</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest11 = () => {
   );
 };
 
-export default missinguseMemoTest11;
+export default MissinguseMemoTest11;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest12/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest12/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest12 = () => {
+const MissinguseMemoTest12 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>missinguseMemoTest12</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest12 = () => {
   );
 };
 
-export default missinguseMemoTest12;
+export default MissinguseMemoTest12;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest13/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest13/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest13 = () => {
+const MissinguseMemoTest13 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>missinguseMemoTest13</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest13 = () => {
   );
 };
 
-export default missinguseMemoTest13;
+export default MissinguseMemoTest13;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest14/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest14/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest14 = () => {
+const MissinguseMemoTest14 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>missinguseMemoTest14</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest14 = () => {
   );
 };
 
-export default missinguseMemoTest14;
+export default MissinguseMemoTest14;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest15/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest15/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest15 = () => {
+const MissinguseMemoTest15 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>missinguseMemoTest15</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest15 = () => {
   );
 };
 
-export default missinguseMemoTest15;
+export default MissinguseMemoTest15;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest16/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest16/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest16 = () => {
+const MissinguseMemoTest16 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>missinguseMemoTest16</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest16 = () => {
   );
 };
 
-export default missinguseMemoTest16;
+export default MissinguseMemoTest16;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest17/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest17/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest17 = () => {
+const MissinguseMemoTest17 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>missinguseMemoTest17</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest17 = () => {
   );
 };
 
-export default missinguseMemoTest17;
+export default MissinguseMemoTest17;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest18/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest18/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest18 = () => {
+const MissinguseMemoTest18 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>missinguseMemoTest18</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest18 = () => {
   );
 };
 
-export default missinguseMemoTest18;
+export default MissinguseMemoTest18;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest19/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest19/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest19 = () => {
+const MissinguseMemoTest19 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>missinguseMemoTest19</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest19 = () => {
   );
 };
 
-export default missinguseMemoTest19;
+export default MissinguseMemoTest19;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest2/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest2/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest2 = () => {
+const MissinguseMemoTest2 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>missinguseMemoTest2</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest2 = () => {
   );
 };
 
-export default missinguseMemoTest2;
+export default MissinguseMemoTest2;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest20/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest20/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest20 = () => {
+const MissinguseMemoTest20 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>missinguseMemoTest20</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest20 = () => {
   );
 };
 
-export default missinguseMemoTest20;
+export default MissinguseMemoTest20;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest21/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest21/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest21 = () => {
+const MissinguseMemoTest21 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>missinguseMemoTest21</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest21 = () => {
   );
 };
 
-export default missinguseMemoTest21;
+export default MissinguseMemoTest21;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest22/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest22/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest22 = () => {
+const MissinguseMemoTest22 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>missinguseMemoTest22</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest22 = () => {
   );
 };
 
-export default missinguseMemoTest22;
+export default MissinguseMemoTest22;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest23/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest23/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest23 = () => {
+const MissinguseMemoTest23 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>missinguseMemoTest23</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest23 = () => {
   );
 };
 
-export default missinguseMemoTest23;
+export default MissinguseMemoTest23;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest24/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest24/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest24 = () => {
+const MissinguseMemoTest24 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>missinguseMemoTest24</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest24 = () => {
   );
 };
 
-export default missinguseMemoTest24;
+export default MissinguseMemoTest24;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest25/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest25/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest25 = () => {
+const MissinguseMemoTest25 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>missinguseMemoTest25</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest25 = () => {
   );
 };
 
-export default missinguseMemoTest25;
+export default MissinguseMemoTest25;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest26/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest26/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest26 = () => {
+const MissinguseMemoTest26 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>missinguseMemoTest26</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest26 = () => {
   );
 };
 
-export default missinguseMemoTest26;
+export default MissinguseMemoTest26;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest27/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest27/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest27 = () => {
+const MissinguseMemoTest27 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>missinguseMemoTest27</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest27 = () => {
   );
 };
 
-export default missinguseMemoTest27;
+export default MissinguseMemoTest27;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest28/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest28/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest28 = () => {
+const MissinguseMemoTest28 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>missinguseMemoTest28</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest28 = () => {
   );
 };
 
-export default missinguseMemoTest28;
+export default MissinguseMemoTest28;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest29/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest29/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest29 = () => {
+const MissinguseMemoTest29 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>missinguseMemoTest29</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest29 = () => {
   );
 };
 
-export default missinguseMemoTest29;
+export default MissinguseMemoTest29;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest3/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest3/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest3 = () => {
+const MissinguseMemoTest3 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>missinguseMemoTest3</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest3 = () => {
   );
 };
 
-export default missinguseMemoTest3;
+export default MissinguseMemoTest3;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest30/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest30/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest30 = () => {
+const MissinguseMemoTest30 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>missinguseMemoTest30</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest30 = () => {
   );
 };
 
-export default missinguseMemoTest30;
+export default MissinguseMemoTest30;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest4/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest4/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest4 = () => {
+const MissinguseMemoTest4 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>missinguseMemoTest4</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest4 = () => {
   );
 };
 
-export default missinguseMemoTest4;
+export default MissinguseMemoTest4;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest5/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest5/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest5 = () => {
+const MissinguseMemoTest5 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>missinguseMemoTest5</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest5 = () => {
   );
 };
 
-export default missinguseMemoTest5;
+export default MissinguseMemoTest5;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest6/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest6/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest6 = () => {
+const MissinguseMemoTest6 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>missinguseMemoTest6</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest6 = () => {
   );
 };
 
-export default missinguseMemoTest6;
+export default MissinguseMemoTest6;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest7/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest7/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest7 = () => {
+const MissinguseMemoTest7 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>missinguseMemoTest7</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest7 = () => {
   );
 };
 
-export default missinguseMemoTest7;
+export default MissinguseMemoTest7;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest8/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest8/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest8 = () => {
+const MissinguseMemoTest8 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>missinguseMemoTest8</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest8 = () => {
   );
 };
 
-export default missinguseMemoTest8;
+export default MissinguseMemoTest8;

--- a/synthetic-react-app/src/pages/test-data/missinguseMemoTest9/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/missinguseMemoTest9/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const missinguseMemoTest9 = () => {
+const MissinguseMemoTest9 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>missinguseMemoTest9</h2>
@@ -10,4 +10,4 @@ const missinguseMemoTest9 = () => {
   );
 };
 
-export default missinguseMemoTest9;
+export default MissinguseMemoTest9;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest1/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest1/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest1 = () => {
+const MisuseduseEffectTest1 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>misuseduseEffectTest1</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest1 = () => {
   );
 };
 
-export default misuseduseEffectTest1;
+export default MisuseduseEffectTest1;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest10/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest10/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest10 = () => {
+const MisuseduseEffectTest10 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>misuseduseEffectTest10</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest10 = () => {
   );
 };
 
-export default misuseduseEffectTest10;
+export default MisuseduseEffectTest10;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest11/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest11/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest11 = () => {
+const MisuseduseEffectTest11 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>misuseduseEffectTest11</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest11 = () => {
   );
 };
 
-export default misuseduseEffectTest11;
+export default MisuseduseEffectTest11;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest12/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest12/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest12 = () => {
+const MisuseduseEffectTest12 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>misuseduseEffectTest12</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest12 = () => {
   );
 };
 
-export default misuseduseEffectTest12;
+export default MisuseduseEffectTest12;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest13/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest13/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest13 = () => {
+const MisuseduseEffectTest13 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>misuseduseEffectTest13</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest13 = () => {
   );
 };
 
-export default misuseduseEffectTest13;
+export default MisuseduseEffectTest13;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest14/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest14/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest14 = () => {
+const MisuseduseEffectTest14 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>misuseduseEffectTest14</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest14 = () => {
   );
 };
 
-export default misuseduseEffectTest14;
+export default MisuseduseEffectTest14;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest15/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest15/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest15 = () => {
+const MisuseduseEffectTest15 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>misuseduseEffectTest15</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest15 = () => {
   );
 };
 
-export default misuseduseEffectTest15;
+export default MisuseduseEffectTest15;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest16/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest16/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest16 = () => {
+const MisuseduseEffectTest16 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>misuseduseEffectTest16</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest16 = () => {
   );
 };
 
-export default misuseduseEffectTest16;
+export default MisuseduseEffectTest16;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest17/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest17/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest17 = () => {
+const MisuseduseEffectTest17 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>misuseduseEffectTest17</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest17 = () => {
   );
 };
 
-export default misuseduseEffectTest17;
+export default MisuseduseEffectTest17;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest18/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest18/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest18 = () => {
+const MisuseduseEffectTest18 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>misuseduseEffectTest18</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest18 = () => {
   );
 };
 
-export default misuseduseEffectTest18;
+export default MisuseduseEffectTest18;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest19/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest19/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest19 = () => {
+const MisuseduseEffectTest19 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>misuseduseEffectTest19</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest19 = () => {
   );
 };
 
-export default misuseduseEffectTest19;
+export default MisuseduseEffectTest19;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest2/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest2/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest2 = () => {
+const MisuseduseEffectTest2 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>misuseduseEffectTest2</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest2 = () => {
   );
 };
 
-export default misuseduseEffectTest2;
+export default MisuseduseEffectTest2;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest20/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest20/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest20 = () => {
+const MisuseduseEffectTest20 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>misuseduseEffectTest20</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest20 = () => {
   );
 };
 
-export default misuseduseEffectTest20;
+export default MisuseduseEffectTest20;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest21/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest21/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest21 = () => {
+const MisuseduseEffectTest21 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>misuseduseEffectTest21</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest21 = () => {
   );
 };
 
-export default misuseduseEffectTest21;
+export default MisuseduseEffectTest21;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest22/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest22/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest22 = () => {
+const MisuseduseEffectTest22 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>misuseduseEffectTest22</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest22 = () => {
   );
 };
 
-export default misuseduseEffectTest22;
+export default MisuseduseEffectTest22;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest23/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest23/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest23 = () => {
+const MisuseduseEffectTest23 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>misuseduseEffectTest23</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest23 = () => {
   );
 };
 
-export default misuseduseEffectTest23;
+export default MisuseduseEffectTest23;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest24/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest24/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest24 = () => {
+const MisuseduseEffectTest24 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>misuseduseEffectTest24</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest24 = () => {
   );
 };
 
-export default misuseduseEffectTest24;
+export default MisuseduseEffectTest24;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest25/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest25/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest25 = () => {
+const MisuseduseEffectTest25 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>misuseduseEffectTest25</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest25 = () => {
   );
 };
 
-export default misuseduseEffectTest25;
+export default MisuseduseEffectTest25;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest26/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest26/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest26 = () => {
+const MisuseduseEffectTest26 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>misuseduseEffectTest26</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest26 = () => {
   );
 };
 
-export default misuseduseEffectTest26;
+export default MisuseduseEffectTest26;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest27/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest27/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest27 = () => {
+const MisuseduseEffectTest27 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>misuseduseEffectTest27</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest27 = () => {
   );
 };
 
-export default misuseduseEffectTest27;
+export default MisuseduseEffectTest27;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest28/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest28/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest28 = () => {
+const MisuseduseEffectTest28 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>misuseduseEffectTest28</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest28 = () => {
   );
 };
 
-export default misuseduseEffectTest28;
+export default MisuseduseEffectTest28;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest29/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest29/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest29 = () => {
+const MisuseduseEffectTest29 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>misuseduseEffectTest29</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest29 = () => {
   );
 };
 
-export default misuseduseEffectTest29;
+export default MisuseduseEffectTest29;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest3/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest3/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest3 = () => {
+const MisuseduseEffectTest3 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>misuseduseEffectTest3</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest3 = () => {
   );
 };
 
-export default misuseduseEffectTest3;
+export default MisuseduseEffectTest3;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest30/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest30/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest30 = () => {
+const MisuseduseEffectTest30 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>misuseduseEffectTest30</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest30 = () => {
   );
 };
 
-export default misuseduseEffectTest30;
+export default MisuseduseEffectTest30;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest4/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest4/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest4 = () => {
+const MisuseduseEffectTest4 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>misuseduseEffectTest4</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest4 = () => {
   );
 };
 
-export default misuseduseEffectTest4;
+export default MisuseduseEffectTest4;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest5/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest5/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest5 = () => {
+const MisuseduseEffectTest5 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>misuseduseEffectTest5</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest5 = () => {
   );
 };
 
-export default misuseduseEffectTest5;
+export default MisuseduseEffectTest5;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest6/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest6/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest6 = () => {
+const MisuseduseEffectTest6 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>misuseduseEffectTest6</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest6 = () => {
   );
 };
 
-export default misuseduseEffectTest6;
+export default MisuseduseEffectTest6;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest7/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest7/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest7 = () => {
+const MisuseduseEffectTest7 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>misuseduseEffectTest7</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest7 = () => {
   );
 };
 
-export default misuseduseEffectTest7;
+export default MisuseduseEffectTest7;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest8/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest8/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest8 = () => {
+const MisuseduseEffectTest8 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>misuseduseEffectTest8</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest8 = () => {
   );
 };
 
-export default misuseduseEffectTest8;
+export default MisuseduseEffectTest8;

--- a/synthetic-react-app/src/pages/test-data/misuseduseEffectTest9/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/misuseduseEffectTest9/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const misuseduseEffectTest9 = () => {
+const MisuseduseEffectTest9 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>misuseduseEffectTest9</h2>
@@ -10,4 +10,4 @@ const misuseduseEffectTest9 = () => {
   );
 };
 
-export default misuseduseEffectTest9;
+export default MisuseduseEffectTest9;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest1/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest1/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest1 = () => {
+const PropdrillingTest1 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>propdrillingTest1</h2>
@@ -10,4 +10,4 @@ const propdrillingTest1 = () => {
   );
 };
 
-export default propdrillingTest1;
+export default PropdrillingTest1;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest10/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest10/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest10 = () => {
+const PropdrillingTest10 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>propdrillingTest10</h2>
@@ -10,4 +10,4 @@ const propdrillingTest10 = () => {
   );
 };
 
-export default propdrillingTest10;
+export default PropdrillingTest10;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest11/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest11/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest11 = () => {
+const PropdrillingTest11 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>propdrillingTest11</h2>
@@ -10,4 +10,4 @@ const propdrillingTest11 = () => {
   );
 };
 
-export default propdrillingTest11;
+export default PropdrillingTest11;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest12/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest12/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest12 = () => {
+const PropdrillingTest12 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>propdrillingTest12</h2>
@@ -10,4 +10,4 @@ const propdrillingTest12 = () => {
   );
 };
 
-export default propdrillingTest12;
+export default PropdrillingTest12;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest13/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest13/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest13 = () => {
+const PropdrillingTest13 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>propdrillingTest13</h2>
@@ -10,4 +10,4 @@ const propdrillingTest13 = () => {
   );
 };
 
-export default propdrillingTest13;
+export default PropdrillingTest13;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest14/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest14/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest14 = () => {
+const PropdrillingTest14 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>propdrillingTest14</h2>
@@ -10,4 +10,4 @@ const propdrillingTest14 = () => {
   );
 };
 
-export default propdrillingTest14;
+export default PropdrillingTest14;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest15/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest15/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest15 = () => {
+const PropdrillingTest15 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>propdrillingTest15</h2>
@@ -10,4 +10,4 @@ const propdrillingTest15 = () => {
   );
 };
 
-export default propdrillingTest15;
+export default PropdrillingTest15;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest16/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest16/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest16 = () => {
+const PropdrillingTest16 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>propdrillingTest16</h2>
@@ -10,4 +10,4 @@ const propdrillingTest16 = () => {
   );
 };
 
-export default propdrillingTest16;
+export default PropdrillingTest16;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest17/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest17/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest17 = () => {
+const PropdrillingTest17 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>propdrillingTest17</h2>
@@ -10,4 +10,4 @@ const propdrillingTest17 = () => {
   );
 };
 
-export default propdrillingTest17;
+export default PropdrillingTest17;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest18/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest18/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest18 = () => {
+const PropdrillingTest18 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>propdrillingTest18</h2>
@@ -10,4 +10,4 @@ const propdrillingTest18 = () => {
   );
 };
 
-export default propdrillingTest18;
+export default PropdrillingTest18;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest19/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest19/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest19 = () => {
+const PropdrillingTest19 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>propdrillingTest19</h2>
@@ -10,4 +10,4 @@ const propdrillingTest19 = () => {
   );
 };
 
-export default propdrillingTest19;
+export default PropdrillingTest19;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest2/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest2/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest2 = () => {
+const PropdrillingTest2 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>propdrillingTest2</h2>
@@ -10,4 +10,4 @@ const propdrillingTest2 = () => {
   );
 };
 
-export default propdrillingTest2;
+export default PropdrillingTest2;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest20/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest20/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest20 = () => {
+const PropdrillingTest20 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>propdrillingTest20</h2>
@@ -10,4 +10,4 @@ const propdrillingTest20 = () => {
   );
 };
 
-export default propdrillingTest20;
+export default PropdrillingTest20;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest21/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest21/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest21 = () => {
+const PropdrillingTest21 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>propdrillingTest21</h2>
@@ -10,4 +10,4 @@ const propdrillingTest21 = () => {
   );
 };
 
-export default propdrillingTest21;
+export default PropdrillingTest21;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest22/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest22/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest22 = () => {
+const PropdrillingTest22 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>propdrillingTest22</h2>
@@ -10,4 +10,4 @@ const propdrillingTest22 = () => {
   );
 };
 
-export default propdrillingTest22;
+export default PropdrillingTest22;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest23/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest23/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest23 = () => {
+const PropdrillingTest23 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>propdrillingTest23</h2>
@@ -10,4 +10,4 @@ const propdrillingTest23 = () => {
   );
 };
 
-export default propdrillingTest23;
+export default PropdrillingTest23;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest24/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest24/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest24 = () => {
+const PropdrillingTest24 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>propdrillingTest24</h2>
@@ -10,4 +10,4 @@ const propdrillingTest24 = () => {
   );
 };
 
-export default propdrillingTest24;
+export default PropdrillingTest24;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest25/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest25/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest25 = () => {
+const PropdrillingTest25 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>propdrillingTest25</h2>
@@ -10,4 +10,4 @@ const propdrillingTest25 = () => {
   );
 };
 
-export default propdrillingTest25;
+export default PropdrillingTest25;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest26/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest26/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest26 = () => {
+const PropdrillingTest26 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>propdrillingTest26</h2>
@@ -10,4 +10,4 @@ const propdrillingTest26 = () => {
   );
 };
 
-export default propdrillingTest26;
+export default PropdrillingTest26;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest27/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest27/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest27 = () => {
+const PropdrillingTest27 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>propdrillingTest27</h2>
@@ -10,4 +10,4 @@ const propdrillingTest27 = () => {
   );
 };
 
-export default propdrillingTest27;
+export default PropdrillingTest27;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest28/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest28/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest28 = () => {
+const PropdrillingTest28 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>propdrillingTest28</h2>
@@ -10,4 +10,4 @@ const propdrillingTest28 = () => {
   );
 };
 
-export default propdrillingTest28;
+export default PropdrillingTest28;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest29/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest29/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest29 = () => {
+const PropdrillingTest29 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>propdrillingTest29</h2>
@@ -10,4 +10,4 @@ const propdrillingTest29 = () => {
   );
 };
 
-export default propdrillingTest29;
+export default PropdrillingTest29;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest3/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest3/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest3 = () => {
+const PropdrillingTest3 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>propdrillingTest3</h2>
@@ -10,4 +10,4 @@ const propdrillingTest3 = () => {
   );
 };
 
-export default propdrillingTest3;
+export default PropdrillingTest3;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest30/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest30/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest30 = () => {
+const PropdrillingTest30 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>propdrillingTest30</h2>
@@ -10,4 +10,4 @@ const propdrillingTest30 = () => {
   );
 };
 
-export default propdrillingTest30;
+export default PropdrillingTest30;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest4/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest4/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest4 = () => {
+const PropdrillingTest4 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>propdrillingTest4</h2>
@@ -10,4 +10,4 @@ const propdrillingTest4 = () => {
   );
 };
 
-export default propdrillingTest4;
+export default PropdrillingTest4;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest5/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest5/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest5 = () => {
+const PropdrillingTest5 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>propdrillingTest5</h2>
@@ -10,4 +10,4 @@ const propdrillingTest5 = () => {
   );
 };
 
-export default propdrillingTest5;
+export default PropdrillingTest5;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest6/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest6/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest6 = () => {
+const PropdrillingTest6 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>propdrillingTest6</h2>
@@ -10,4 +10,4 @@ const propdrillingTest6 = () => {
   );
 };
 
-export default propdrillingTest6;
+export default PropdrillingTest6;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest7/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest7/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest7 = () => {
+const PropdrillingTest7 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>propdrillingTest7</h2>
@@ -10,4 +10,4 @@ const propdrillingTest7 = () => {
   );
 };
 
-export default propdrillingTest7;
+export default PropdrillingTest7;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest8/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest8/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest8 = () => {
+const PropdrillingTest8 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>propdrillingTest8</h2>
@@ -10,4 +10,4 @@ const propdrillingTest8 = () => {
   );
 };
 
-export default propdrillingTest8;
+export default PropdrillingTest8;

--- a/synthetic-react-app/src/pages/test-data/propdrillingTest9/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/propdrillingTest9/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const propdrillingTest9 = () => {
+const PropdrillingTest9 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>propdrillingTest9</h2>
@@ -10,4 +10,4 @@ const propdrillingTest9 = () => {
   );
 };
 
-export default propdrillingTest9;
+export default PropdrillingTest9;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest1/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest1/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest1 = () => {
+const RepeatedfetchingTest1 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>repeatedfetchingTest1</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest1 = () => {
   );
 };
 
-export default repeatedfetchingTest1;
+export default RepeatedfetchingTest1;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest10/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest10/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest10 = () => {
+const RepeatedfetchingTest10 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>repeatedfetchingTest10</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest10 = () => {
   );
 };
 
-export default repeatedfetchingTest10;
+export default RepeatedfetchingTest10;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest11/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest11/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest11 = () => {
+const RepeatedfetchingTest11 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>repeatedfetchingTest11</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest11 = () => {
   );
 };
 
-export default repeatedfetchingTest11;
+export default RepeatedfetchingTest11;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest12/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest12/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest12 = () => {
+const RepeatedfetchingTest12 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>repeatedfetchingTest12</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest12 = () => {
   );
 };
 
-export default repeatedfetchingTest12;
+export default RepeatedfetchingTest12;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest13/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest13/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest13 = () => {
+const RepeatedfetchingTest13 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>repeatedfetchingTest13</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest13 = () => {
   );
 };
 
-export default repeatedfetchingTest13;
+export default RepeatedfetchingTest13;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest14/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest14/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest14 = () => {
+const RepeatedfetchingTest14 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>repeatedfetchingTest14</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest14 = () => {
   );
 };
 
-export default repeatedfetchingTest14;
+export default RepeatedfetchingTest14;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest15/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest15/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest15 = () => {
+const RepeatedfetchingTest15 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>repeatedfetchingTest15</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest15 = () => {
   );
 };
 
-export default repeatedfetchingTest15;
+export default RepeatedfetchingTest15;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest16/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest16/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest16 = () => {
+const RepeatedfetchingTest16 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>repeatedfetchingTest16</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest16 = () => {
   );
 };
 
-export default repeatedfetchingTest16;
+export default RepeatedfetchingTest16;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest17/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest17/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest17 = () => {
+const RepeatedfetchingTest17 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>repeatedfetchingTest17</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest17 = () => {
   );
 };
 
-export default repeatedfetchingTest17;
+export default RepeatedfetchingTest17;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest18/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest18/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest18 = () => {
+const RepeatedfetchingTest18 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>repeatedfetchingTest18</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest18 = () => {
   );
 };
 
-export default repeatedfetchingTest18;
+export default RepeatedfetchingTest18;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest19/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest19/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest19 = () => {
+const RepeatedfetchingTest19 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>repeatedfetchingTest19</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest19 = () => {
   );
 };
 
-export default repeatedfetchingTest19;
+export default RepeatedfetchingTest19;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest2/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest2/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest2 = () => {
+const RepeatedfetchingTest2 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>repeatedfetchingTest2</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest2 = () => {
   );
 };
 
-export default repeatedfetchingTest2;
+export default RepeatedfetchingTest2;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest20/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest20/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest20 = () => {
+const RepeatedfetchingTest20 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>repeatedfetchingTest20</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest20 = () => {
   );
 };
 
-export default repeatedfetchingTest20;
+export default RepeatedfetchingTest20;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest21/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest21/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest21 = () => {
+const RepeatedfetchingTest21 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>repeatedfetchingTest21</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest21 = () => {
   );
 };
 
-export default repeatedfetchingTest21;
+export default RepeatedfetchingTest21;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest22/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest22/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest22 = () => {
+const RepeatedfetchingTest22 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>repeatedfetchingTest22</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest22 = () => {
   );
 };
 
-export default repeatedfetchingTest22;
+export default RepeatedfetchingTest22;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest23/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest23/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest23 = () => {
+const RepeatedfetchingTest23 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>repeatedfetchingTest23</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest23 = () => {
   );
 };
 
-export default repeatedfetchingTest23;
+export default RepeatedfetchingTest23;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest24/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest24/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest24 = () => {
+const RepeatedfetchingTest24 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>repeatedfetchingTest24</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest24 = () => {
   );
 };
 
-export default repeatedfetchingTest24;
+export default RepeatedfetchingTest24;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest25/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest25/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest25 = () => {
+const RepeatedfetchingTest25 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>repeatedfetchingTest25</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest25 = () => {
   );
 };
 
-export default repeatedfetchingTest25;
+export default RepeatedfetchingTest25;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest26/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest26/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest26 = () => {
+const RepeatedfetchingTest26 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>repeatedfetchingTest26</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest26 = () => {
   );
 };
 
-export default repeatedfetchingTest26;
+export default RepeatedfetchingTest26;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest27/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest27/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest27 = () => {
+const RepeatedfetchingTest27 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>repeatedfetchingTest27</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest27 = () => {
   );
 };
 
-export default repeatedfetchingTest27;
+export default RepeatedfetchingTest27;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest28/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest28/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest28 = () => {
+const RepeatedfetchingTest28 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>repeatedfetchingTest28</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest28 = () => {
   );
 };
 
-export default repeatedfetchingTest28;
+export default RepeatedfetchingTest28;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest29/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest29/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest29 = () => {
+const RepeatedfetchingTest29 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>repeatedfetchingTest29</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest29 = () => {
   );
 };
 
-export default repeatedfetchingTest29;
+export default RepeatedfetchingTest29;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest3/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest3/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest3 = () => {
+const RepeatedfetchingTest3 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>repeatedfetchingTest3</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest3 = () => {
   );
 };
 
-export default repeatedfetchingTest3;
+export default RepeatedfetchingTest3;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest30/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest30/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest30 = () => {
+const RepeatedfetchingTest30 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>repeatedfetchingTest30</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest30 = () => {
   );
 };
 
-export default repeatedfetchingTest30;
+export default RepeatedfetchingTest30;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest4/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest4/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest4 = () => {
+const RepeatedfetchingTest4 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>repeatedfetchingTest4</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest4 = () => {
   );
 };
 
-export default repeatedfetchingTest4;
+export default RepeatedfetchingTest4;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest5/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest5/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest5 = () => {
+const RepeatedfetchingTest5 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>repeatedfetchingTest5</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest5 = () => {
   );
 };
 
-export default repeatedfetchingTest5;
+export default RepeatedfetchingTest5;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest6/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest6/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest6 = () => {
+const RepeatedfetchingTest6 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>repeatedfetchingTest6</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest6 = () => {
   );
 };
 
-export default repeatedfetchingTest6;
+export default RepeatedfetchingTest6;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest7/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest7/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest7 = () => {
+const RepeatedfetchingTest7 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>repeatedfetchingTest7</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest7 = () => {
   );
 };
 
-export default repeatedfetchingTest7;
+export default RepeatedfetchingTest7;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest8/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest8/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest8 = () => {
+const RepeatedfetchingTest8 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>repeatedfetchingTest8</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest8 = () => {
   );
 };
 
-export default repeatedfetchingTest8;
+export default RepeatedfetchingTest8;

--- a/synthetic-react-app/src/pages/test-data/repeatedfetchingTest9/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/repeatedfetchingTest9/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const repeatedfetchingTest9 = () => {
+const RepeatedfetchingTest9 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>repeatedfetchingTest9</h2>
@@ -10,4 +10,4 @@ const repeatedfetchingTest9 = () => {
   );
 };
 
-export default repeatedfetchingTest9;
+export default RepeatedfetchingTest9;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest1/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest1/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest1 = () => {
+const StaleclosuresTest1 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>staleclosuresTest1</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest1 = () => {
   );
 };
 
-export default staleclosuresTest1;
+export default StaleclosuresTest1;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest10/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest10/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest10 = () => {
+const StaleclosuresTest10 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>staleclosuresTest10</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest10 = () => {
   );
 };
 
-export default staleclosuresTest10;
+export default StaleclosuresTest10;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest11/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest11/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest11 = () => {
+const StaleclosuresTest11 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>staleclosuresTest11</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest11 = () => {
   );
 };
 
-export default staleclosuresTest11;
+export default StaleclosuresTest11;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest12/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest12/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest12 = () => {
+const StaleclosuresTest12 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>staleclosuresTest12</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest12 = () => {
   );
 };
 
-export default staleclosuresTest12;
+export default StaleclosuresTest12;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest13/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest13/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest13 = () => {
+const StaleclosuresTest13 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>staleclosuresTest13</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest13 = () => {
   );
 };
 
-export default staleclosuresTest13;
+export default StaleclosuresTest13;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest14/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest14/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest14 = () => {
+const StaleclosuresTest14 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>staleclosuresTest14</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest14 = () => {
   );
 };
 
-export default staleclosuresTest14;
+export default StaleclosuresTest14;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest15/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest15/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest15 = () => {
+const StaleclosuresTest15 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>staleclosuresTest15</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest15 = () => {
   );
 };
 
-export default staleclosuresTest15;
+export default StaleclosuresTest15;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest16/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest16/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest16 = () => {
+const StaleclosuresTest16 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>staleclosuresTest16</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest16 = () => {
   );
 };
 
-export default staleclosuresTest16;
+export default StaleclosuresTest16;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest17/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest17/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest17 = () => {
+const StaleclosuresTest17 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>staleclosuresTest17</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest17 = () => {
   );
 };
 
-export default staleclosuresTest17;
+export default StaleclosuresTest17;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest18/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest18/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest18 = () => {
+const StaleclosuresTest18 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>staleclosuresTest18</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest18 = () => {
   );
 };
 
-export default staleclosuresTest18;
+export default StaleclosuresTest18;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest19/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest19/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest19 = () => {
+const StaleclosuresTest19 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>staleclosuresTest19</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest19 = () => {
   );
 };
 
-export default staleclosuresTest19;
+export default StaleclosuresTest19;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest2/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest2/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest2 = () => {
+const StaleclosuresTest2 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>staleclosuresTest2</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest2 = () => {
   );
 };
 
-export default staleclosuresTest2;
+export default StaleclosuresTest2;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest20/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest20/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest20 = () => {
+const StaleclosuresTest20 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>staleclosuresTest20</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest20 = () => {
   );
 };
 
-export default staleclosuresTest20;
+export default StaleclosuresTest20;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest21/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest21/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest21 = () => {
+const StaleclosuresTest21 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>staleclosuresTest21</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest21 = () => {
   );
 };
 
-export default staleclosuresTest21;
+export default StaleclosuresTest21;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest22/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest22/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest22 = () => {
+const StaleclosuresTest22 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>staleclosuresTest22</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest22 = () => {
   );
 };
 
-export default staleclosuresTest22;
+export default StaleclosuresTest22;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest23/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest23/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest23 = () => {
+const StaleclosuresTest23 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>staleclosuresTest23</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest23 = () => {
   );
 };
 
-export default staleclosuresTest23;
+export default StaleclosuresTest23;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest24/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest24/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest24 = () => {
+const StaleclosuresTest24 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>staleclosuresTest24</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest24 = () => {
   );
 };
 
-export default staleclosuresTest24;
+export default StaleclosuresTest24;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest25/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest25/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest25 = () => {
+const StaleclosuresTest25 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>staleclosuresTest25</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest25 = () => {
   );
 };
 
-export default staleclosuresTest25;
+export default StaleclosuresTest25;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest26/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest26/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest26 = () => {
+const StaleclosuresTest26 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>staleclosuresTest26</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest26 = () => {
   );
 };
 
-export default staleclosuresTest26;
+export default StaleclosuresTest26;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest27/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest27/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest27 = () => {
+const StaleclosuresTest27 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>staleclosuresTest27</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest27 = () => {
   );
 };
 
-export default staleclosuresTest27;
+export default StaleclosuresTest27;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest28/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest28/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest28 = () => {
+const StaleclosuresTest28 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>staleclosuresTest28</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest28 = () => {
   );
 };
 
-export default staleclosuresTest28;
+export default StaleclosuresTest28;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest29/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest29/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest29 = () => {
+const StaleclosuresTest29 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>staleclosuresTest29</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest29 = () => {
   );
 };
 
-export default staleclosuresTest29;
+export default StaleclosuresTest29;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest3/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest3/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest3 = () => {
+const StaleclosuresTest3 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>staleclosuresTest3</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest3 = () => {
   );
 };
 
-export default staleclosuresTest3;
+export default StaleclosuresTest3;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest30/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest30/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest30 = () => {
+const StaleclosuresTest30 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>staleclosuresTest30</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest30 = () => {
   );
 };
 
-export default staleclosuresTest30;
+export default StaleclosuresTest30;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest4/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest4/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest4 = () => {
+const StaleclosuresTest4 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>staleclosuresTest4</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest4 = () => {
   );
 };
 
-export default staleclosuresTest4;
+export default StaleclosuresTest4;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest5/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest5/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest5 = () => {
+const StaleclosuresTest5 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>staleclosuresTest5</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest5 = () => {
   );
 };
 
-export default staleclosuresTest5;
+export default StaleclosuresTest5;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest6/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest6/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest6 = () => {
+const StaleclosuresTest6 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>staleclosuresTest6</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest6 = () => {
   );
 };
 
-export default staleclosuresTest6;
+export default StaleclosuresTest6;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest7/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest7/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest7 = () => {
+const StaleclosuresTest7 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>staleclosuresTest7</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest7 = () => {
   );
 };
 
-export default staleclosuresTest7;
+export default StaleclosuresTest7;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest8/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest8/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest8 = () => {
+const StaleclosuresTest8 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>staleclosuresTest8</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest8 = () => {
   );
 };
 
-export default staleclosuresTest8;
+export default StaleclosuresTest8;

--- a/synthetic-react-app/src/pages/test-data/staleclosuresTest9/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/staleclosuresTest9/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const staleclosuresTest9 = () => {
+const StaleclosuresTest9 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>staleclosuresTest9</h2>
@@ -10,4 +10,4 @@ const staleclosuresTest9 = () => {
   );
 };
 
-export default staleclosuresTest9;
+export default StaleclosuresTest9;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest1/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest1/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest1 = () => {
+const ToomanyeffectsTest1 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>toomanyeffectsTest1</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest1 = () => {
   );
 };
 
-export default toomanyeffectsTest1;
+export default ToomanyeffectsTest1;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest10/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest10/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest10 = () => {
+const ToomanyeffectsTest10 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>toomanyeffectsTest10</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest10 = () => {
   );
 };
 
-export default toomanyeffectsTest10;
+export default ToomanyeffectsTest10;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest11/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest11/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest11 = () => {
+const ToomanyeffectsTest11 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>toomanyeffectsTest11</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest11 = () => {
   );
 };
 
-export default toomanyeffectsTest11;
+export default ToomanyeffectsTest11;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest12/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest12/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest12 = () => {
+const ToomanyeffectsTest12 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>toomanyeffectsTest12</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest12 = () => {
   );
 };
 
-export default toomanyeffectsTest12;
+export default ToomanyeffectsTest12;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest13/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest13/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest13 = () => {
+const ToomanyeffectsTest13 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>toomanyeffectsTest13</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest13 = () => {
   );
 };
 
-export default toomanyeffectsTest13;
+export default ToomanyeffectsTest13;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest14/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest14/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest14 = () => {
+const ToomanyeffectsTest14 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>toomanyeffectsTest14</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest14 = () => {
   );
 };
 
-export default toomanyeffectsTest14;
+export default ToomanyeffectsTest14;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest15/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest15/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest15 = () => {
+const ToomanyeffectsTest15 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>toomanyeffectsTest15</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest15 = () => {
   );
 };
 
-export default toomanyeffectsTest15;
+export default ToomanyeffectsTest15;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest16/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest16/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest16 = () => {
+const ToomanyeffectsTest16 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>toomanyeffectsTest16</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest16 = () => {
   );
 };
 
-export default toomanyeffectsTest16;
+export default ToomanyeffectsTest16;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest17/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest17/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest17 = () => {
+const ToomanyeffectsTest17 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>toomanyeffectsTest17</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest17 = () => {
   );
 };
 
-export default toomanyeffectsTest17;
+export default ToomanyeffectsTest17;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest18/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest18/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest18 = () => {
+const ToomanyeffectsTest18 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>toomanyeffectsTest18</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest18 = () => {
   );
 };
 
-export default toomanyeffectsTest18;
+export default ToomanyeffectsTest18;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest19/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest19/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest19 = () => {
+const ToomanyeffectsTest19 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>toomanyeffectsTest19</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest19 = () => {
   );
 };
 
-export default toomanyeffectsTest19;
+export default ToomanyeffectsTest19;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest2/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest2/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest2 = () => {
+const ToomanyeffectsTest2 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>toomanyeffectsTest2</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest2 = () => {
   );
 };
 
-export default toomanyeffectsTest2;
+export default ToomanyeffectsTest2;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest20/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest20/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest20 = () => {
+const ToomanyeffectsTest20 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>toomanyeffectsTest20</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest20 = () => {
   );
 };
 
-export default toomanyeffectsTest20;
+export default ToomanyeffectsTest20;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest21/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest21/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest21 = () => {
+const ToomanyeffectsTest21 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>toomanyeffectsTest21</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest21 = () => {
   );
 };
 
-export default toomanyeffectsTest21;
+export default ToomanyeffectsTest21;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest22/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest22/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest22 = () => {
+const ToomanyeffectsTest22 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>toomanyeffectsTest22</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest22 = () => {
   );
 };
 
-export default toomanyeffectsTest22;
+export default ToomanyeffectsTest22;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest23/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest23/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest23 = () => {
+const ToomanyeffectsTest23 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>toomanyeffectsTest23</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest23 = () => {
   );
 };
 
-export default toomanyeffectsTest23;
+export default ToomanyeffectsTest23;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest24/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest24/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest24 = () => {
+const ToomanyeffectsTest24 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>toomanyeffectsTest24</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest24 = () => {
   );
 };
 
-export default toomanyeffectsTest24;
+export default ToomanyeffectsTest24;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest25/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest25/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest25 = () => {
+const ToomanyeffectsTest25 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>toomanyeffectsTest25</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest25 = () => {
   );
 };
 
-export default toomanyeffectsTest25;
+export default ToomanyeffectsTest25;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest26/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest26/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest26 = () => {
+const ToomanyeffectsTest26 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>toomanyeffectsTest26</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest26 = () => {
   );
 };
 
-export default toomanyeffectsTest26;
+export default ToomanyeffectsTest26;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest27/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest27/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest27 = () => {
+const ToomanyeffectsTest27 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>toomanyeffectsTest27</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest27 = () => {
   );
 };
 
-export default toomanyeffectsTest27;
+export default ToomanyeffectsTest27;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest28/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest28/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest28 = () => {
+const ToomanyeffectsTest28 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>toomanyeffectsTest28</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest28 = () => {
   );
 };
 
-export default toomanyeffectsTest28;
+export default ToomanyeffectsTest28;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest29/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest29/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest29 = () => {
+const ToomanyeffectsTest29 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>toomanyeffectsTest29</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest29 = () => {
   );
 };
 
-export default toomanyeffectsTest29;
+export default ToomanyeffectsTest29;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest3/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest3/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest3 = () => {
+const ToomanyeffectsTest3 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>toomanyeffectsTest3</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest3 = () => {
   );
 };
 
-export default toomanyeffectsTest3;
+export default ToomanyeffectsTest3;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest30/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest30/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest30 = () => {
+const ToomanyeffectsTest30 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>toomanyeffectsTest30</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest30 = () => {
   );
 };
 
-export default toomanyeffectsTest30;
+export default ToomanyeffectsTest30;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest4/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest4/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest4 = () => {
+const ToomanyeffectsTest4 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>toomanyeffectsTest4</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest4 = () => {
   );
 };
 
-export default toomanyeffectsTest4;
+export default ToomanyeffectsTest4;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest5/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest5/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest5 = () => {
+const ToomanyeffectsTest5 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>toomanyeffectsTest5</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest5 = () => {
   );
 };
 
-export default toomanyeffectsTest5;
+export default ToomanyeffectsTest5;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest6/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest6/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest6 = () => {
+const ToomanyeffectsTest6 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>toomanyeffectsTest6</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest6 = () => {
   );
 };
 
-export default toomanyeffectsTest6;
+export default ToomanyeffectsTest6;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest7/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest7/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest7 = () => {
+const ToomanyeffectsTest7 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>toomanyeffectsTest7</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest7 = () => {
   );
 };
 
-export default toomanyeffectsTest7;
+export default ToomanyeffectsTest7;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest8/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest8/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest8 = () => {
+const ToomanyeffectsTest8 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>toomanyeffectsTest8</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest8 = () => {
   );
 };
 
-export default toomanyeffectsTest8;
+export default ToomanyeffectsTest8;

--- a/synthetic-react-app/src/pages/test-data/toomanyeffectsTest9/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/toomanyeffectsTest9/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const toomanyeffectsTest9 = () => {
+const ToomanyeffectsTest9 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>toomanyeffectsTest9</h2>
@@ -10,4 +10,4 @@ const toomanyeffectsTest9 = () => {
   );
 };
 
-export default toomanyeffectsTest9;
+export default ToomanyeffectsTest9;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest1/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest1/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest1 = () => {
+const UnstablepropsTest1 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>unstablepropsTest1</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest1 = () => {
   );
 };
 
-export default unstablepropsTest1;
+export default UnstablepropsTest1;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest10/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest10/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest10 = () => {
+const UnstablepropsTest10 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>unstablepropsTest10</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest10 = () => {
   );
 };
 
-export default unstablepropsTest10;
+export default UnstablepropsTest10;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest11/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest11/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest11 = () => {
+const UnstablepropsTest11 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>unstablepropsTest11</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest11 = () => {
   );
 };
 
-export default unstablepropsTest11;
+export default UnstablepropsTest11;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest12/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest12/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest12 = () => {
+const UnstablepropsTest12 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>unstablepropsTest12</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest12 = () => {
   );
 };
 
-export default unstablepropsTest12;
+export default UnstablepropsTest12;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest13/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest13/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest13 = () => {
+const UnstablepropsTest13 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>unstablepropsTest13</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest13 = () => {
   );
 };
 
-export default unstablepropsTest13;
+export default UnstablepropsTest13;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest14/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest14/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest14 = () => {
+const UnstablepropsTest14 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>unstablepropsTest14</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest14 = () => {
   );
 };
 
-export default unstablepropsTest14;
+export default UnstablepropsTest14;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest15/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest15/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest15 = () => {
+const UnstablepropsTest15 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>unstablepropsTest15</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest15 = () => {
   );
 };
 
-export default unstablepropsTest15;
+export default UnstablepropsTest15;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest16/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest16/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest16 = () => {
+const UnstablepropsTest16 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>unstablepropsTest16</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest16 = () => {
   );
 };
 
-export default unstablepropsTest16;
+export default UnstablepropsTest16;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest17/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest17/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest17 = () => {
+const UnstablepropsTest17 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>unstablepropsTest17</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest17 = () => {
   );
 };
 
-export default unstablepropsTest17;
+export default UnstablepropsTest17;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest18/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest18/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest18 = () => {
+const UnstablepropsTest18 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>unstablepropsTest18</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest18 = () => {
   );
 };
 
-export default unstablepropsTest18;
+export default UnstablepropsTest18;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest19/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest19/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest19 = () => {
+const UnstablepropsTest19 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>unstablepropsTest19</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest19 = () => {
   );
 };
 
-export default unstablepropsTest19;
+export default UnstablepropsTest19;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest2/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest2/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest2 = () => {
+const UnstablepropsTest2 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>unstablepropsTest2</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest2 = () => {
   );
 };
 
-export default unstablepropsTest2;
+export default UnstablepropsTest2;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest20/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest20/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest20 = () => {
+const UnstablepropsTest20 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>unstablepropsTest20</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest20 = () => {
   );
 };
 
-export default unstablepropsTest20;
+export default UnstablepropsTest20;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest21/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest21/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest21 = () => {
+const UnstablepropsTest21 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>unstablepropsTest21</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest21 = () => {
   );
 };
 
-export default unstablepropsTest21;
+export default UnstablepropsTest21;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest22/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest22/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest22 = () => {
+const UnstablepropsTest22 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>unstablepropsTest22</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest22 = () => {
   );
 };
 
-export default unstablepropsTest22;
+export default UnstablepropsTest22;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest23/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest23/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest23 = () => {
+const UnstablepropsTest23 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>unstablepropsTest23</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest23 = () => {
   );
 };
 
-export default unstablepropsTest23;
+export default UnstablepropsTest23;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest24/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest24/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest24 = () => {
+const UnstablepropsTest24 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>unstablepropsTest24</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest24 = () => {
   );
 };
 
-export default unstablepropsTest24;
+export default UnstablepropsTest24;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest25/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest25/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest25 = () => {
+const UnstablepropsTest25 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>unstablepropsTest25</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest25 = () => {
   );
 };
 
-export default unstablepropsTest25;
+export default UnstablepropsTest25;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest26/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest26/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest26 = () => {
+const UnstablepropsTest26 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>unstablepropsTest26</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest26 = () => {
   );
 };
 
-export default unstablepropsTest26;
+export default UnstablepropsTest26;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest27/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest27/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest27 = () => {
+const UnstablepropsTest27 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>unstablepropsTest27</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest27 = () => {
   );
 };
 
-export default unstablepropsTest27;
+export default UnstablepropsTest27;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest28/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest28/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest28 = () => {
+const UnstablepropsTest28 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>unstablepropsTest28</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest28 = () => {
   );
 };
 
-export default unstablepropsTest28;
+export default UnstablepropsTest28;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest29/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest29/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest29 = () => {
+const UnstablepropsTest29 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>unstablepropsTest29</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest29 = () => {
   );
 };
 
-export default unstablepropsTest29;
+export default UnstablepropsTest29;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest3/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest3/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest3 = () => {
+const UnstablepropsTest3 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>unstablepropsTest3</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest3 = () => {
   );
 };
 
-export default unstablepropsTest3;
+export default UnstablepropsTest3;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest30/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest30/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest30 = () => {
+const UnstablepropsTest30 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>unstablepropsTest30</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest30 = () => {
   );
 };
 
-export default unstablepropsTest30;
+export default UnstablepropsTest30;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest4/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest4/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest4 = () => {
+const UnstablepropsTest4 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>unstablepropsTest4</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest4 = () => {
   );
 };
 
-export default unstablepropsTest4;
+export default UnstablepropsTest4;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest5/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest5/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest5 = () => {
+const UnstablepropsTest5 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>unstablepropsTest5</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest5 = () => {
   );
 };
 
-export default unstablepropsTest5;
+export default UnstablepropsTest5;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest6/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest6/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest6 = () => {
+const UnstablepropsTest6 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>unstablepropsTest6</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest6 = () => {
   );
 };
 
-export default unstablepropsTest6;
+export default UnstablepropsTest6;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest7/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest7/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest7 = () => {
+const UnstablepropsTest7 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>unstablepropsTest7</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest7 = () => {
   );
 };
 
-export default unstablepropsTest7;
+export default UnstablepropsTest7;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest8/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest8/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest8 = () => {
+const UnstablepropsTest8 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <h2>unstablepropsTest8</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest8 = () => {
   );
 };
 
-export default unstablepropsTest8;
+export default UnstablepropsTest8;

--- a/synthetic-react-app/src/pages/test-data/unstablepropsTest9/index.tsx
+++ b/synthetic-react-app/src/pages/test-data/unstablepropsTest9/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const unstablepropsTest9 = () => {
+const UnstablepropsTest9 = () => {
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
       <h2>unstablepropsTest9</h2>
@@ -10,4 +10,4 @@ const unstablepropsTest9 = () => {
   );
 };
 
-export default unstablepropsTest9;
+export default UnstablepropsTest9;

--- a/synthetic-react-app/src/templates/Page.ejs
+++ b/synthetic-react-app/src/templates/Page.ejs
@@ -1,7 +1,7 @@
 import React from 'react';
 import Parent from './Parent';
 
-const <%= pageName %> = () => {
+const <%= componentName %> = () => {
   return (
     <div style={{ display: 'flex', flexDirection: '<%= layout %>' }}>
       <h2><%= pageName %></h2>
@@ -10,4 +10,4 @@ const <%= pageName %> = () => {
   );
 };
 
-export default <%= pageName %>;
+export default <%= componentName %>;


### PR DESCRIPTION
## Summary
- generate page components with PascalCase names
- regenerate test pages

## Testing
- `yarn build` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6856443aaa188325ae72a6a43cea5154