### PR TITLE
Add remote LLM option

### DIFF
--- a/ml/README.md
+++ b/ml/README.md
@@ -33,3 +33,26 @@ directory. Run:
 pip install -r requirements.txt
 python shap_analysis.py
 ```
+
+## Optimisation CLI
+
+`optimise_cli.py` can analyse a React project and optionally generate optimised
+code with an LLM. You may use a local transformers model with `--llm` or call a
+remote OpenAI model with `--openai-model`.
+
+### Local model
+
+```bash
+python optimise_cli.py /path/to/project --llm path/to/model
+```
+
+### Remote OpenAI model
+
+1. Install the `openai` package: `pip install openai`
+2. Set the `OPENAI_API_KEY` environment variable with your API key. Optionally
+   set `OPENAI_API_BASE` if using a compatible endpoint.
+3. Run the CLI specifying the model name:
+
+```bash
+python optimise_cli.py /path/to/project --openai-model gpt-3.5-turbo
+```

--- a/ml/requirements.txt
+++ b/ml/requirements.txt
@@ -3,3 +3,4 @@ scikit-learn
 matplotlib
 scipy<1.12
 shap
+openai


### PR DESCRIPTION
## Summary
- allow using an OpenAI API model instead of a local transformers model
- document CLI usage for local and remote models
- list the openai package in requirements

## Testing
- `python -m py_compile ml/optimise_cli.py`
- `python -m py_compile ml/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685bb39c6f48832599a07c0c86cd18da