### PR TITLE
Improve local LLM generation feedback

### DIFF
--- a/ml/README.md
+++ b/ml/README.md
@@ -39,9 +39,10 @@ python shap_analysis.py
 `optimise_cli.py` can analyse a React project and optionally generate optimised
 code with an LLM. You may use a local transformers model with `--llm` or call a
 remote OpenAI model with `--openai-model`. Pass `--verbose` to see detailed logs
-during the generation step, including progress messages while a local model is
-loading. Both decoder-only and sequence-to-sequence models are supported; the
-CLI automatically detects the correct architecture when loading a local model.
+during the generation step. When using a local model, tokens are streamed to the
+terminal so you can monitor progress in real time. Both decoder-only and
+sequence-to-sequence models are supported; the CLI automatically detects the
+correct architecture when loading a local model.
 
 
 ### Local model

--- a/ml/optimise_cli.py
+++ b/ml/optimise_cli.py
@@ -21,7 +21,9 @@ from transformers import (
     AutoTokenizer,
     AutoModelForCausalLM,
     AutoModelForSeq2SeqLM,
+    TextIteratorStreamer,
 )
+import threading
 import torch
 
 
@@ -311,18 +313,28 @@ def main():
                         logging.info("Local model loaded")
                         inputs = tokenizer(prompt, return_tensors="pt").to(model.device)
                         logging.info("Generating with local model")
-                        with torch.no_grad():
-                            max_pos = getattr(
-                                model.config,
-                                "max_position_embeddings",
-                                getattr(model.config, "n_positions", 2048),
-                            )
-                            output_limit = min(1024, max_pos - len(inputs['input_ids'][0]))
-                            outputs = model.generate(
-                                **inputs, max_new_tokens=output_limit, do_sample=False
-                            )
-
-                        generated = tokenizer.decode(outputs[0], skip_special_tokens=True).strip()
+                        streamer = TextIteratorStreamer(tokenizer, skip_special_tokens=True)
+                        max_pos = getattr(
+                            model.config,
+                            "max_position_embeddings",
+                            getattr(model.config, "n_positions", 2048),
+                        )
+                        output_limit = min(1024, max_pos - len(inputs["input_ids"][0]))
+                        gen_kwargs = {
+                            **inputs,
+                            "max_new_tokens": output_limit,
+                            "do_sample": False,
+                            "streamer": streamer,
+                        }
+                        thread = threading.Thread(target=model.generate, kwargs=gen_kwargs)
+                        thread.start()
+                        tokens = []
+                        for token in streamer:
+                            tokens.append(token)
+                            print(token, end="", flush=True)
+                        thread.join()
+                        print()
+                        generated = "".join(tokens).strip()
                         logging.debug("Local generation complete")
 
 

--- a/ml/requirements.txt
+++ b/ml/requirements.txt
@@ -4,3 +4,4 @@ matplotlib
 scipy<1.12
 shap
 openai
+transformers


### PR DESCRIPTION
## Summary
- stream generation tokens when falling back to a local model
- document streaming progress in the optimisation CLI README
- add transformers to requirements

## Testing
- `python -m pip install -r ml/requirements.txt`
- `python -m py_compile ml/optimise_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_685c25b2795883258ef0b4fc552afe2b