### PR TITLE
Add evaluation script for React code performance

### DIFF
--- a/ml/evaluate_code.py
+++ b/ml/evaluate_code.py
@@ -1,0 +1,36 @@
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+NODE_SCRIPT = HERE.parent / 'synthetic-react-app' / 'scripts' / 'perf_puppeteer.js'
+
+
+def measure(tsx_path: Path, out_json: Path) -> dict:
+    cmd = ['node', str(NODE_SCRIPT), str(tsx_path), str(out_json)]
+    try:
+        subprocess.run(cmd, check=True, capture_output=True)
+        with open(out_json) as f:
+            return json.load(f)
+    except Exception as e:
+        print(f'Failed to run {cmd}: {e}')
+        return {}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('original', help='Path to original TSX file')
+    parser.add_argument('updated', help='Path to updated TSX file')
+    args = parser.parse_args()
+    orig_metrics = measure(Path(args.original), Path('orig_metrics.json'))
+    upd_metrics = measure(Path(args.updated), Path('upd_metrics.json'))
+    print('Original metrics:', orig_metrics)
+    print('Updated metrics:', upd_metrics)
+
+    if orig_metrics and upd_metrics:
+        delta = upd_metrics.get('loadTimeMs', 0) - orig_metrics.get('loadTimeMs', 0)
+        print('Delta loadTimeMs:', delta)
+
+if __name__ == '__main__':
+    main()

--- a/ml/requirements.txt
+++ b/ml/requirements.txt
@@ -5,3 +5,7 @@ scipy<1.12
 shap
 openai
 transformers
+xgboost
+lightgbm
+imbalanced-learn
+python-dotenv


### PR DESCRIPTION
## Summary
- add evaluation script to run Puppeteer performance checks
- extend requirements with ML and CLI dependencies

## Testing
- `python ml/generate_dataset.py`
- `python ml/optimise_cli.py synthetic-react-app/src/pages/test-data/propdrillingTest3 --print-prompt-only`


------
https://chatgpt.com/codex/tasks/task_e_685c4cf86c2c832586680a793930fadd